### PR TITLE
Fix build by adjusting target and compiler options

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,10 @@
 set -e
 
 echo "[*] Building kernel"
-cargo +nightly build -Z build-std=core --target x86_64-gos.json
+cargo +nightly build \
+    -Z build-std=core,compiler_builtins \
+    -Z build-std-features=compiler-builtins-mem \
+    --target x86_64-gos.json
 
 echo "[*] Copying kernel to ISO folder"
 mkdir -p iso/boot/grub

--- a/x86_64-gos.json
+++ b/x86_64-gos.json
@@ -5,7 +5,6 @@
   "vendor": "unknown",
   "linker-flavor": "ld.lld",
   "disable-redzone": true,
-  "features": "-mmx,-sse,+soft-float",
   "panic-strategy": "abort",
   "executables": true,
   "relocation-model": "static",


### PR DESCRIPTION
## Summary
- update `x86_64-gos.json` to remove invalid feature flags
- build compiler_builtins with mem intrinsics in `run.sh`

## Testing
- `cargo +nightly build -Z build-std=core,compiler_builtins -Z build-std-features=compiler-builtins-mem --target x86_64-gos.json`

------
https://chatgpt.com/codex/tasks/task_b_6843bcede524832d9560cf7b3eaf176b